### PR TITLE
DRAFT: untested difference-list deforestation transform

### DIFF
--- a/dyna/__init__.py
+++ b/dyna/__init__.py
@@ -23,5 +23,10 @@ from dyna.derivations import Derivation, Derivations
 from dyna import derivations
 
 from dyna.transform import Fold, Unfold, Slash, LCT
+from dyna.transform.deforest import (
+    DeforestDifferenceLists,
+    DifferenceListDeforestationSpec,
+    deforest_difference_lists,
+)
 from dyna.transform.measure import make_smt_measure
 from dyna.propagate import ConstraintPropagation

--- a/dyna/transform/__init__.py
+++ b/dyna/transform/__init__.py
@@ -2,3 +2,8 @@ from dyna.transform.fold import Fold, fold_r_S, prune_r_S
 from dyna.transform.unfold import Unfold
 from dyna.transform.slash import Slash
 from dyna.transform.lct import LCT
+from dyna.transform.deforest import (
+    DeforestDifferenceLists,
+    DifferenceListDeforestationSpec,
+    deforest_difference_lists,
+)

--- a/dyna/transform/deforest.py
+++ b/dyna/transform/deforest.py
@@ -1,0 +1,255 @@
+"""Deforestation passes for producer/consumer algebraic data channels.
+
+This module currently implements a deliberately small, conservative pass for the
+classic pattern
+
+    gen(A, Acc, X) * equal(X, In)
+
+where `gen` is a difference-list CFG generator and `equal` is structural list
+equality against an observed input.  The residual program uses suffix-list tails
+as finite states and introduces a span predicate.
+
+The pass is intentionally phrased as a Dyna-to-Dyna transformation: it removes
+only the recognized generator/equality definitions and emits ordinary Dyna rules.
+It does not require demand-driven execution, and it does not rely on a
+parser-specific CKY template beyond the residual predicate shape discovered from
+this producer/consumer pattern.
+"""
+
+from dataclasses import dataclass
+
+from dyna import Product, Rule, Subst, Term, TransformedProgram, Var, fresh
+
+
+NIL = Term('$nil')
+
+
+def CONS(head, tail):
+    return Term('$cons', head, tail)
+
+
+@dataclass(frozen=True)
+class DifferenceListDeforestationSpec:
+    """Names used by the difference-list/intersection idiom.
+
+    The defaults match the example in the tests.  `span_fn` and `suffix_fn` may
+    be left as `None`; the transform will choose `$span`/`$suffix`, avoiding
+    collisions with symbols already present in the program.
+    """
+
+    gen_fn: str = 'gen'
+    equal_fn: str = 'equal'
+    rule_term_fn: str = 'rule_term'
+    rule_bin_fn: str = 'rule_bin'
+    root_fn: str = 'root'
+    source_fn: str = 'source_string'
+    eq_fn: str = 'eq'
+    span_fn: str | None = None
+    suffix_fn: str | None = None
+
+
+def _matches(rule, head_pattern, body_patterns):
+    """Yield matches of `head_pattern += body_patterns` against `rule`.
+
+    Body matching is conjunctive/subset-style: `body_patterns` may cover a
+    subset of the rule body, and the unmatched body factors are returned as
+    residual factors.  This lets the transform preserve extra weights/guards on
+    the source rules.
+    """
+
+    subst = Subst().cover(head_pattern, rule.head)
+    if subst is None:
+        return
+    yield from Product(body_patterns).covers(rule.body, subst)
+
+
+def _require_one(program, head_pattern, body_patterns, label):
+    found = []
+    for i, rule in enumerate(program):
+        for subst, _align, remaining in _matches(rule, head_pattern, body_patterns):
+            found.append((i, rule, subst, remaining))
+            break
+    if len(found) != 1:
+        raise ValueError(f'expected exactly one {label} rule, found {len(found)}')
+    return found[0]
+
+
+def _require_at_least_one(program, head_pattern, body_patterns, label):
+    found = []
+    for i, rule in enumerate(program):
+        for subst, _align, remaining in _matches(rule, head_pattern, body_patterns):
+            found.append((i, rule, subst, remaining))
+            break
+    if not found:
+        raise ValueError(f'expected at least one {label} rule')
+    return found
+
+
+def _compile_difference_list_intersection(parent, spec):
+    span_fn = spec.span_fn or parent._gen_functor('$span')
+    suffix_fn = spec.suffix_fn or parent._gen_functor('$suffix')
+
+    # ------------------------------------------------------------------
+    # Recognize terminal generator rule:
+    #   gen(A, Acc, [W|Acc]) += rule_term(A, W) * extra.
+    A = Var('A'); Acc = Var('Acc'); W = Var('W')
+    term_i, term_rule, term_subst, term_remaining = _require_one(
+        parent,
+        Term(spec.gen_fn, A, Acc, CONS(W, Acc)),
+        [Term(spec.rule_term_fn, A, W)],
+        'difference-list terminal generator',
+    )
+
+    # Recognize binary generator rule:
+    #   gen(A, Acc, X) += rule_bin(A,B,C) * gen(C,Acc,Mid) * gen(B,Mid,X) * extra.
+    A = Var('A'); Acc = Var('Acc'); X = Var('X')
+    B = Var('B'); C = Var('C'); Mid = Var('Mid')
+    bin_i, bin_rule, bin_subst, bin_remaining = _require_one(
+        parent,
+        Term(spec.gen_fn, A, Acc, X),
+        [
+            Term(spec.rule_bin_fn, A, B, C),
+            Term(spec.gen_fn, C, Acc, Mid),
+            Term(spec.gen_fn, B, Mid, X),
+        ],
+        'difference-list binary generator',
+    )
+
+    # Recognize structural list equality.  These rules are removed after fusion.
+    base_i, _base_rule, _base_subst, _base_remaining = _require_one(
+        parent,
+        Term(spec.equal_fn, NIL, NIL),
+        [],
+        'structural equality base',
+    )
+
+    X0 = Var('X'); Xs = Var('Xs'); Y0 = Var('Y'); Ys = Var('Ys')
+    rec_i, _rec_rule, _rec_subst, _rec_remaining = _require_one(
+        parent,
+        Term(spec.equal_fn, CONS(X0, Xs), CONS(Y0, Ys)),
+        [Term(spec.equal_fn, Xs, Ys), Term(spec.eq_fn, X0, Y0)],
+        'structural equality recursive case',
+    )
+
+    # Recognize all top-level intersections of a root generator with the source.
+    S = Var('S'); Str = Var('Str'); In = Var('In')
+    goal_matches = _require_at_least_one(
+        parent,
+        Var('Head'),
+        [
+            Term(spec.root_fn, S),
+            Term(spec.gen_fn, S, NIL, Str),
+            Term(spec.source_fn, In),
+            Term(spec.equal_fn, Str, In),
+        ],
+        'top-level generator/source intersection',
+    )
+
+    remove = {term_i, bin_i, base_i, rec_i, *(i for i, *_ in goal_matches)}
+    new_rules = [rule for i, rule in enumerate(parent) if i not in remove]
+
+    # ------------------------------------------------------------------
+    # Suffix-state automaton for the observed source list.
+    #   $suffix(In)   += source_string(In).
+    #   $suffix(Rest) += $suffix([V|Rest]).
+    In = Var('In')
+    V = Var('V')
+    Rest = Var('Rest')
+    new_rules.append(fresh(Rule(
+        Term(suffix_fn, In),
+        Term(spec.source_fn, In),
+    )))
+    new_rules.append(fresh(Rule(
+        Term(suffix_fn, Rest),
+        Term(suffix_fn, CONS(V, Rest)),
+    )))
+
+    # Terminal residual:
+    #   span(A, [V|Acc], Acc) += suffix([V|Acc]) * rule_term(A,W) * eq(W,V) * extra.
+    A = term_subst(Var('A'))   # will not work: use stable pattern vars below
+    # The comments above describe the source-level binding.  Recreate the source
+    # pattern variables so we can read their substitutions from the match.
+    TA = Var('A'); TAcc = Var('Acc'); TW = Var('W')
+    # Re-match in a tiny local scope to get handles for the actual source variables.
+    # This avoids relying on variable names: the substitutions map pattern Var
+    # objects to the variables/terms in the source rule.
+    term_pat_head = Term(spec.gen_fn, TA, TAcc, CONS(TW, TAcc))
+    term_pat_body = [Term(spec.rule_term_fn, TA, TW)]
+    [(term_subst2, _align, _remaining)] = list(_matches(term_rule, term_pat_head, term_pat_body))
+    A = term_subst2(TA); Acc = term_subst2(TAcc); W = term_subst2(TW)
+    V = Var('V')
+    start_tail = CONS(V, Acc)
+    term_extra = [term_rule.body[k] for k in term_remaining]
+    new_rules.append(fresh(Rule(
+        Term(span_fn, A, start_tail, Acc),
+        Term(suffix_fn, start_tail),
+        Term(spec.rule_term_fn, A, W),
+        Term(spec.eq_fn, W, V),
+        *term_extra,
+    )))
+
+    # Binary residual:
+    #   span(A, X, Acc) += rule_bin(A,B,C) * span(B,X,Mid) * span(C,Mid,Acc) * extra.
+    BA = Var('A'); BAcc = Var('Acc'); BX = Var('X')
+    BB = Var('B'); BC = Var('C'); BMid = Var('Mid')
+    bin_pat_head = Term(spec.gen_fn, BA, BAcc, BX)
+    bin_pat_body = [
+        Term(spec.rule_bin_fn, BA, BB, BC),
+        Term(spec.gen_fn, BC, BAcc, BMid),
+        Term(spec.gen_fn, BB, BMid, BX),
+    ]
+    [(bin_subst2, _align, _remaining)] = list(_matches(bin_rule, bin_pat_head, bin_pat_body))
+    A = bin_subst2(BA); Acc = bin_subst2(BAcc); X = bin_subst2(BX)
+    B = bin_subst2(BB); C = bin_subst2(BC); Mid = bin_subst2(BMid)
+    bin_extra = [bin_rule.body[k] for k in bin_remaining]
+    new_rules.append(fresh(Rule(
+        Term(span_fn, A, X, Acc),
+        Term(spec.rule_bin_fn, A, B, C),
+        Term(span_fn, B, X, Mid),
+        Term(span_fn, C, Mid, Acc),
+        *bin_extra,
+    )))
+
+    # Top-level residual(s): replace root/gen/source/equal by root/source/span.
+    for _i, goal_rule, _subst, remaining in goal_matches:
+        GS = Var('S'); GStr = Var('Str'); GIn = Var('In')
+        H = Var('Head')
+        goal_pat_head = H
+        goal_pat_body = [
+            Term(spec.root_fn, GS),
+            Term(spec.gen_fn, GS, NIL, GStr),
+            Term(spec.source_fn, GIn),
+            Term(spec.equal_fn, GStr, GIn),
+        ]
+        [(goal_subst, _align, _remaining)] = list(_matches(goal_rule, goal_pat_head, goal_pat_body))
+        S = goal_subst(GS); In = goal_subst(GIn)
+        extra = [goal_rule.body[k] for k in remaining]
+        new_rules.append(fresh(Rule(
+            goal_rule.head,
+            Term(spec.root_fn, S),
+            Term(spec.source_fn, In),
+            Term(span_fn, S, In, NIL),
+            *extra,
+        )))
+
+    return new_rules
+
+
+class DeforestDifferenceLists(TransformedProgram):
+    """Fuse a difference-list generator with structural equality on its output.
+
+    The residual program uses suffix list tails as chart states.  For a source
+    list of length `n`, there are only `n+1` suffix states, so the binary CFG
+    rule has the usual cubic span/split search space.
+    """
+
+    def __init__(self, parent, **kwargs):
+        self.spec = DifferenceListDeforestationSpec(**kwargs)
+        rules = _compile_difference_list_intersection(parent, self.spec)
+        super().__init__('deforest-difference-lists', parent, rules)
+
+
+def deforest_difference_lists(program, **kwargs):
+    """Return a Dyna-to-Dyna deforestation of the recognized DL/intersection idiom."""
+
+    return DeforestDifferenceLists(program, **kwargs)

--- a/dyna/transform/deforest.py
+++ b/dyna/transform/deforest.py
@@ -17,6 +17,7 @@ this producer/consumer pattern.
 """
 
 from dataclasses import dataclass
+from typing import Optional
 
 from dyna import Product, Rule, Subst, Term, TransformedProgram, Var, fresh
 
@@ -30,12 +31,7 @@ def CONS(head, tail):
 
 @dataclass(frozen=True)
 class DifferenceListDeforestationSpec:
-    """Names used by the difference-list/intersection idiom.
-
-    The defaults match the example in the tests.  `span_fn` and `suffix_fn` may
-    be left as `None`; the transform will choose `$span`/`$suffix`, avoiding
-    collisions with symbols already present in the program.
-    """
+    """Names used by the difference-list/intersection idiom."""
 
     gen_fn: str = 'gen'
     equal_fn: str = 'equal'
@@ -44,8 +40,8 @@ class DifferenceListDeforestationSpec:
     root_fn: str = 'root'
     source_fn: str = 'source_string'
     eq_fn: str = 'eq'
-    span_fn: str | None = None
-    suffix_fn: str | None = None
+    span_fn: Optional[str] = None
+    suffix_fn: Optional[str] = None
 
 
 def _matches(rule, head_pattern, body_patterns):
@@ -85,15 +81,54 @@ def _require_at_least_one(program, head_pattern, body_patterns, label):
     return found
 
 
+def _source_variables_for_terminal(rule, spec):
+    A = Var('A'); Acc = Var('Acc'); W = Var('W')
+    [(subst, _align, _remaining)] = list(_matches(
+        rule,
+        Term(spec.gen_fn, A, Acc, CONS(W, Acc)),
+        [Term(spec.rule_term_fn, A, W)],
+    ))
+    return subst(A), subst(Acc), subst(W)
+
+
+def _source_variables_for_binary(rule, spec):
+    A = Var('A'); Acc = Var('Acc'); X = Var('X')
+    B = Var('B'); C = Var('C'); Mid = Var('Mid')
+    [(subst, _align, _remaining)] = list(_matches(
+        rule,
+        Term(spec.gen_fn, A, Acc, X),
+        [
+            Term(spec.rule_bin_fn, A, B, C),
+            Term(spec.gen_fn, C, Acc, Mid),
+            Term(spec.gen_fn, B, Mid, X),
+        ],
+    ))
+    return subst(A), subst(Acc), subst(X), subst(B), subst(C), subst(Mid)
+
+
+def _source_variables_for_goal(rule, spec):
+    S = Var('S'); Str = Var('Str'); In = Var('In')
+    [(subst, _align, _remaining)] = list(_matches(
+        rule,
+        Var('Head'),
+        [
+            Term(spec.root_fn, S),
+            Term(spec.gen_fn, S, NIL, Str),
+            Term(spec.source_fn, In),
+            Term(spec.equal_fn, Str, In),
+        ],
+    ))
+    return subst(S), subst(In)
+
+
 def _compile_difference_list_intersection(parent, spec):
     span_fn = spec.span_fn or parent._gen_functor('$span')
     suffix_fn = spec.suffix_fn or parent._gen_functor('$suffix')
 
-    # ------------------------------------------------------------------
     # Recognize terminal generator rule:
     #   gen(A, Acc, [W|Acc]) += rule_term(A, W) * extra.
     A = Var('A'); Acc = Var('Acc'); W = Var('W')
-    term_i, term_rule, term_subst, term_remaining = _require_one(
+    term_i, term_rule, _term_subst, term_remaining = _require_one(
         parent,
         Term(spec.gen_fn, A, Acc, CONS(W, Acc)),
         [Term(spec.rule_term_fn, A, W)],
@@ -104,7 +139,7 @@ def _compile_difference_list_intersection(parent, spec):
     #   gen(A, Acc, X) += rule_bin(A,B,C) * gen(C,Acc,Mid) * gen(B,Mid,X) * extra.
     A = Var('A'); Acc = Var('Acc'); X = Var('X')
     B = Var('B'); C = Var('C'); Mid = Var('Mid')
-    bin_i, bin_rule, bin_subst, bin_remaining = _require_one(
+    bin_i, bin_rule, _bin_subst, bin_remaining = _require_one(
         parent,
         Term(spec.gen_fn, A, Acc, X),
         [
@@ -148,8 +183,7 @@ def _compile_difference_list_intersection(parent, spec):
     remove = {term_i, bin_i, base_i, rec_i, *(i for i, *_ in goal_matches)}
     new_rules = [rule for i, rule in enumerate(parent) if i not in remove]
 
-    # ------------------------------------------------------------------
-    # Suffix-state automaton for the observed source list.
+    # Suffix-state automaton for the observed source list:
     #   $suffix(In)   += source_string(In).
     #   $suffix(Rest) += $suffix([V|Rest]).
     In = Var('In')
@@ -166,17 +200,7 @@ def _compile_difference_list_intersection(parent, spec):
 
     # Terminal residual:
     #   span(A, [V|Acc], Acc) += suffix([V|Acc]) * rule_term(A,W) * eq(W,V) * extra.
-    A = term_subst(Var('A'))   # will not work: use stable pattern vars below
-    # The comments above describe the source-level binding.  Recreate the source
-    # pattern variables so we can read their substitutions from the match.
-    TA = Var('A'); TAcc = Var('Acc'); TW = Var('W')
-    # Re-match in a tiny local scope to get handles for the actual source variables.
-    # This avoids relying on variable names: the substitutions map pattern Var
-    # objects to the variables/terms in the source rule.
-    term_pat_head = Term(spec.gen_fn, TA, TAcc, CONS(TW, TAcc))
-    term_pat_body = [Term(spec.rule_term_fn, TA, TW)]
-    [(term_subst2, _align, _remaining)] = list(_matches(term_rule, term_pat_head, term_pat_body))
-    A = term_subst2(TA); Acc = term_subst2(TAcc); W = term_subst2(TW)
+    A, Acc, W = _source_variables_for_terminal(term_rule, spec)
     V = Var('V')
     start_tail = CONS(V, Acc)
     term_extra = [term_rule.body[k] for k in term_remaining]
@@ -190,17 +214,7 @@ def _compile_difference_list_intersection(parent, spec):
 
     # Binary residual:
     #   span(A, X, Acc) += rule_bin(A,B,C) * span(B,X,Mid) * span(C,Mid,Acc) * extra.
-    BA = Var('A'); BAcc = Var('Acc'); BX = Var('X')
-    BB = Var('B'); BC = Var('C'); BMid = Var('Mid')
-    bin_pat_head = Term(spec.gen_fn, BA, BAcc, BX)
-    bin_pat_body = [
-        Term(spec.rule_bin_fn, BA, BB, BC),
-        Term(spec.gen_fn, BC, BAcc, BMid),
-        Term(spec.gen_fn, BB, BMid, BX),
-    ]
-    [(bin_subst2, _align, _remaining)] = list(_matches(bin_rule, bin_pat_head, bin_pat_body))
-    A = bin_subst2(BA); Acc = bin_subst2(BAcc); X = bin_subst2(BX)
-    B = bin_subst2(BB); C = bin_subst2(BC); Mid = bin_subst2(BMid)
+    A, Acc, X, B, C, Mid = _source_variables_for_binary(bin_rule, spec)
     bin_extra = [bin_rule.body[k] for k in bin_remaining]
     new_rules.append(fresh(Rule(
         Term(span_fn, A, X, Acc),
@@ -212,17 +226,7 @@ def _compile_difference_list_intersection(parent, spec):
 
     # Top-level residual(s): replace root/gen/source/equal by root/source/span.
     for _i, goal_rule, _subst, remaining in goal_matches:
-        GS = Var('S'); GStr = Var('Str'); GIn = Var('In')
-        H = Var('Head')
-        goal_pat_head = H
-        goal_pat_body = [
-            Term(spec.root_fn, GS),
-            Term(spec.gen_fn, GS, NIL, GStr),
-            Term(spec.source_fn, GIn),
-            Term(spec.equal_fn, GStr, GIn),
-        ]
-        [(goal_subst, _align, _remaining)] = list(_matches(goal_rule, goal_pat_head, goal_pat_body))
-        S = goal_subst(GS); In = goal_subst(GIn)
+        S, In = _source_variables_for_goal(goal_rule, spec)
         extra = [goal_rule.body[k] for k in remaining]
         new_rules.append(fresh(Rule(
             goal_rule.head,

--- a/test/test_deforest.py
+++ b/test/test_deforest.py
@@ -1,0 +1,58 @@
+from dyna import Program, deforest_difference_lists
+
+
+def test_difference_list_intersection_to_suffix_spans():
+    p = Program("""
+    inputs: source_string(_); root(_); rule_term(_,_); rule_bin(_,_,_); eq(_,_).
+    outputs: goal.
+
+    gen(A, Acc, [W|Acc]) += rule_term(A, W).
+    gen(A, Acc, X) += rule_bin(A, B, C) * gen(C, Acc, Mid) * gen(B, Mid, X).
+
+    equal([], []).
+    equal([X|Xs], [Y|Ys]) += equal(Xs, Ys) * eq(X, Y).
+
+    goal += root(S) * gen(S, [], Str) * source_string(In) * equal(Str, In).
+    """)
+
+    q = deforest_difference_lists(p)
+
+    q.assert_equal("""
+    $suffix(In) += source_string(In).
+    $suffix(Rest) += $suffix([V|Rest]).
+
+    $span(A, [V|Acc], Acc) += $suffix([V|Acc]) * rule_term(A, W) * eq(W, V).
+    $span(A, X, Acc) += rule_bin(A, B, C) * $span(B, X, Mid) * $span(C, Mid, Acc).
+
+    goal += root(S) * source_string(In) * $span(S, In, []).
+    """)
+
+    assert all(r.head.fn != 'gen' for r in q if hasattr(r.head, 'fn'))
+    assert all(r.head.fn != 'equal' for r in q if hasattr(r.head, 'fn'))
+
+
+def test_difference_list_deforestation_preserves_extra_factors():
+    p = Program("""
+    inputs: source_string(_); root(_); rule_term(_,_); rule_bin(_,_,_); eq(_,_); ok(_).
+    outputs: goal.
+
+    gen(A, Acc, [W|Acc]) += rule_term(A, W) * ok(A).
+    gen(A, Acc, X) += rule_bin(A, B, C) * gen(C, Acc, Mid) * gen(B, Mid, X).
+
+    equal([], []).
+    equal([X|Xs], [Y|Ys]) += equal(Xs, Ys) * eq(X, Y).
+
+    goal += root(S) * gen(S, [], Str) * source_string(In) * equal(Str, In).
+    """)
+
+    q = deforest_difference_lists(p)
+
+    q.assert_equal("""
+    $suffix(In) += source_string(In).
+    $suffix(Rest) += $suffix([V|Rest]).
+
+    $span(A, [V|Acc], Acc) += $suffix([V|Acc]) * rule_term(A, W) * eq(W, V) * ok(A).
+    $span(A, X, Acc) += rule_bin(A, B, C) * $span(B, X, Mid) * $span(C, Mid, Acc).
+
+    goal += root(S) * source_string(In) * $span(S, In, []).
+    """)


### PR DESCRIPTION
Status: **draft / untested**.

The initial PR was opened before tests had run, which was a mistake. The GitHub Actions run for the head commit was cancelled, so this should not be treated as review-ready yet.

This branch currently contains a conservative Dyna-to-Dyna deforestation pass for the difference-list generator / structural-equality intersection idiom:

```dyna
gen(A, Acc, X) * equal(X, In)
```

The transform recognizes the terminal and binary `gen` rules, the structural list `equal` rules, and top-level `root/gen/source_string/equal` intersections. It removes the generated-list witness and emits a suffix-state residual program with `$suffix` and `$span` predicates.

The residual program uses concrete suffix list tails as finite states rather than integer positions, so it stays entirely in ordinary Dyna terms:

```dyna
$suffix(In) += source_string(In).
$suffix(Rest) += $suffix([V|Rest]).
$span(A, [V|Acc], Acc) += $suffix([V|Acc]) * rule_term(A, W) * eq(W, V).
$span(A, X, Acc) += rule_bin(A, B, C) * $span(B, X, Mid) * $span(C, Mid, Acc).
goal += root(S) * source_string(In) * $span(S, In, []).
```

Included tests:
- basic transformation of the example program
- preservation of extra terminal-side factors

Notes:
- This is intentionally a conservative recognizer/rewriter, not a full general conjunctive unfold/fold search engine yet.
- It does not implement derivation-level `transform`/`untransform` mappings.
- Needs local `pytest test/test_deforest.py` and probably a fix pass before review.